### PR TITLE
Cleanup/add and clean pulsing heli

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -388,8 +388,8 @@ void Copter::allocate_motors(void)
             motors_var_info = AP_MotorsMatrix::var_info;
             break;
         case AP_Motors::MOTOR_FRAME_PULSING_COAX:
-            motors = new AP_MotorsPulsing(ahrs_view, copter.scheduler.get_loop_rate_hz());
-            motors_var_info = AP_MotorsPulsing::var_info;
+            motors = new AP_MotorsPulsing_Coax(ahrs_view, copter.scheduler.get_loop_rate_hz());
+            motors_var_info = AP_MotorsPulsing_Coax::var_info;
             break;
         case AP_Motors::MOTOR_FRAME_PULSING_HELI:
             motors = new AP_MotorsPulsing_Heli(ahrs_view, copter.scheduler.get_loop_rate_hz());

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -391,6 +391,10 @@ void Copter::allocate_motors(void)
             motors = new AP_MotorsPulsing(ahrs_view, copter.scheduler.get_loop_rate_hz());
             motors_var_info = AP_MotorsPulsing::var_info;
             break;
+        case AP_Motors::MOTOR_FRAME_PULSING_HELI:
+            motors = new AP_MotorsPulsing_Heli(ahrs_view, copter.scheduler.get_loop_rate_hz());
+            motors_var_info = AP_MotorsPulsing_Heli::var_info;
+            break;
         case AP_Motors::MOTOR_FRAME_TRI:
             motors = new AP_MotorsTri(copter.scheduler.get_loop_rate_hz());
             motors_var_info = AP_MotorsTri::var_info;

--- a/libraries/AP_Motors/AP_Motors.h
+++ b/libraries/AP_Motors/AP_Motors.h
@@ -14,3 +14,4 @@
 #include "AP_MotorsMatrix_6DoF_Scripting.h"
 #include "AP_MotorsMatrix_Scripting_Dynamic.h"
 #include "AP_MotorsPulsing_Coax.h"
+#include "AP_MotorsPulsing_Heli.h"

--- a/libraries/AP_Motors/AP_MotorsPulsing.cpp
+++ b/libraries/AP_Motors/AP_MotorsPulsing.cpp
@@ -170,21 +170,7 @@ void AP_MotorsPulsing::output_armed_stabilizing()
 
     throttle_avg_max = constrain_float(throttle_avg_max, throttle_thrust, _throttle_thrust_max);
 
-    float rp_thrust_max = MAX(fabsf(roll_thrust), fabsf(pitch_thrust));
 
-    // calculate how much roll and pitch must be scaled to leave enough range for the minimum yaw
-    if (rp_thrust_max >= 1.0f) {
-        rp_scale = constrain_float(1.0f / rp_thrust_max, 0.0f, 1.0f);
-        if (rp_scale < 1.0f) {
-            limit.roll = true;
-            limit.pitch = true;
-        }
-    }
-
-    if (fabsf(yaw_thrust) > 1.0f) {
-        yaw_thrust = constrain_float(1.0f / yaw_thrust, -1.0f, 1.0f);
-        limit.yaw = true;
-    }
 
 
     // calculate the throttle setting for the lift fan

--- a/libraries/AP_Motors/AP_MotorsPulsing_Coax.cpp
+++ b/libraries/AP_Motors/AP_MotorsPulsing_Coax.cpp
@@ -6,19 +6,19 @@
 
 extern const AP_HAL::HAL& hal;
 
-const AP_Param::GroupInfo AP_MotorsPulsing::var_info[] = {
+const AP_Param::GroupInfo AP_MotorsPulsing_Coax::var_info[] = {
     AP_NESTEDGROUPINFO(AP_MotorsMulticopter, 0),
     // @Param: YAW_DIR
     // @DisplayName: Motor normal or reverse
     // @Description: Used to change motor rotation directions without changing wires
     // @Values: 1:normal,-1:reverse
     // @User: Standard
-    AP_GROUPINFO("YAW_DIR", 1, AP_MotorsPulsing, _yaw_dir, 1),
+    AP_GROUPINFO("YAW_DIR", 1, AP_MotorsPulsing_Coax, _yaw_dir, 1),
 
     AP_GROUPEND
 };
 // init
-void AP_MotorsPulsing::init(motor_frame_class frame_class, motor_frame_type frame_type)
+void AP_MotorsPulsing_Coax::init(motor_frame_class frame_class, motor_frame_type frame_type)
 {
     // 1 - Bottom Throttle
     // 2 - Top Throttle
@@ -54,13 +54,13 @@ void AP_MotorsPulsing::init(motor_frame_class frame_class, motor_frame_type fram
 }
 
 // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
-void AP_MotorsPulsing::set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type)
+void AP_MotorsPulsing_Coax::set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type)
 {
     set_initialised_ok(frame_class == MOTOR_FRAME_PULSING_COAX);
 }
 
 // set update rate to motors - a value in hertz
-void AP_MotorsPulsing::set_update_rate(uint16_t speed_hz)
+void AP_MotorsPulsing_Coax::set_update_rate(uint16_t speed_hz)
 {
     // record requested speed
     _speed_hz = speed_hz;
@@ -71,7 +71,7 @@ void AP_MotorsPulsing::set_update_rate(uint16_t speed_hz)
     rc_set_freq(mask, _speed_hz);
 }
 
-void AP_MotorsPulsing::output_to_motors()
+void AP_MotorsPulsing_Coax::output_to_motors()
 {
     switch (_spool_state) {
         case SpoolState::SHUT_DOWN:
@@ -120,7 +120,7 @@ void AP_MotorsPulsing::output_to_motors()
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
 //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
-uint32_t AP_MotorsPulsing::get_motor_mask()
+uint32_t AP_MotorsPulsing_Coax::get_motor_mask()
 {
     uint32_t motor_mask =
         1U << AP_MOTORS_MOT_1 |
@@ -133,7 +133,7 @@ uint32_t AP_MotorsPulsing::get_motor_mask()
     return mask;
 }
 
-void AP_MotorsPulsing::output_armed_stabilizing()
+void AP_MotorsPulsing_Coax::output_armed_stabilizing()
 {
     float   roll_thrust;                // roll thrust input value, +/- 1.0
     float   pitch_thrust;               // pitch thrust input value, +/- 1.0
@@ -179,7 +179,7 @@ void AP_MotorsPulsing::output_armed_stabilizing()
 // output_test_seq - spin a motor at the pwm value specified
 //  motor_seq is the motor's sequence number from 1 to the number of motors on the frame
 //  pwm value is an actual pwm value that will be output, normally in the range of 1000 ~ 2000
-void AP_MotorsPulsing::_output_test_seq(uint8_t motor_seq, int16_t pwm)
+void AP_MotorsPulsing_Coax::_output_test_seq(uint8_t motor_seq, int16_t pwm)
 {
     // output to motors and servos
     switch (motor_seq) {

--- a/libraries/AP_Motors/AP_MotorsPulsing_Coax.h
+++ b/libraries/AP_Motors/AP_MotorsPulsing_Coax.h
@@ -10,9 +10,9 @@
 
 #define AP_MOTORS_COAX_SERVO_INPUT_RANGE    4500
 
-class AP_MotorsPulsing : public AP_MotorsMulticopter {
+class AP_MotorsPulsing_Coax : public AP_MotorsMulticopter {
 public:
-    AP_MotorsPulsing(AP_AHRS_View  *ahrs_view, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
+    AP_MotorsPulsing_Coax(AP_AHRS_View  *ahrs_view, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
         AP_MotorsMulticopter(speed_hz), _ahrs_view(ahrs_view)
     {
         AP_Param::setup_object_defaults(this, var_info);

--- a/libraries/AP_Motors/AP_MotorsPulsing_Heli.cpp
+++ b/libraries/AP_Motors/AP_MotorsPulsing_Heli.cpp
@@ -126,6 +126,8 @@ uint32_t AP_MotorsPulsing_Heli::get_motor_mask()
     //Our mask is the main rotor, pitch, roll, and the tail rotor
     uint32_t motor_mask =
         1U << AP_MOTORS_MOT_1 |
+        1U << AP_MOTORS_MOT_2 |
+        1U << AP_MOTORS_MOT_3 |
         1U << AP_MOTORS_MOT_4;
     uint32_t mask = motor_mask_to_srv_channel_mask(motor_mask);
 

--- a/libraries/AP_Motors/AP_MotorsPulsing_Heli.cpp
+++ b/libraries/AP_Motors/AP_MotorsPulsing_Heli.cpp
@@ -49,14 +49,12 @@ void AP_MotorsPulsing_Heli::init(motor_frame_class frame_class, motor_frame_type
         add_motor_num(CH_1 + i);
     }
 
-
     // setup actuator scaling
     SRV_Channels::set_angle(SRV_Channels::get_motor_function(1), AP_MOTORS_COAX_SERVO_INPUT_RANGE);
     SRV_Channels::set_angle(SRV_Channels::get_motor_function(2), AP_MOTORS_COAX_SERVO_INPUT_RANGE);
 
     motor_enabled[AP_MOTORS_MOT_1] = true;
     motor_enabled[AP_MOTORS_MOT_4] = true;
-
 
     _mav_type = MAV_TYPE_QUADROTOR;
     rpm = AP_RPM::get_singleton();
@@ -158,7 +156,6 @@ void AP_MotorsPulsing_Heli::output_armed_stabilizing()
     float gyro_x_ff = omega_cross.x * _gyro_ff_gain;
     float gyro_y_ff = omega_cross.y * _gyro_ff_gain;
 
-
     // apply voltage and air pressure compensation
     const float compensation_gain = get_compensation_gain();
     roll_thrust = (_roll_in + _roll_in_ff + gyro_x_ff) * compensation_gain;
@@ -166,7 +163,6 @@ void AP_MotorsPulsing_Heli::output_armed_stabilizing()
     yaw_thrust = (_yaw_in + _yaw_in_ff + rotor_yaw_ff) * compensation_gain;
     throttle_thrust = get_throttle() * compensation_gain;
     throttle_avg_max = _throttle_avg_max * compensation_gain;
-
 
     // sanity check throttle is above zero and below current limited throttle
     if (throttle_thrust <= 0.0f) {

--- a/libraries/AP_Motors/AP_MotorsPulsing_Heli.cpp
+++ b/libraries/AP_Motors/AP_MotorsPulsing_Heli.cpp
@@ -23,7 +23,7 @@ const AP_Param::GroupInfo AP_MotorsPulsing_Heli::var_info[] = {
     // @Increment: float
     // @User: Standard
     AP_GROUPINFO("ROTOR_YAW_FF", 2, AP_MotorsPulsing_Heli, _rotor_yaw_ff, 0),
-    
+
     // @Param: GYRO_FF
     // @DisplayName: Rotor gyroscopic FF gain
     // @Description: Used to add a feed forward term to compensate for the rotor's gyroscopic torque
@@ -43,7 +43,7 @@ void AP_MotorsPulsing_Heli::init(motor_frame_class frame_class, motor_frame_type
     //2: Pitch
     //3: Roll
     //4: Tail rotor thrust
-    
+
     // make sure 4 output channels are mapped
     for (uint8_t i = 0; i < 4; i++) {
         add_motor_num(CH_1 + i);
@@ -90,35 +90,35 @@ void AP_MotorsPulsing_Heli::output_to_motors()
     //If we are in GROUND_IDLE, allow the rotors to spin with throttle with a predefined idle speed, but no pitch or roll
     //In any other state, allow full control of main and tail throttle, pitch, and roll
     switch (_spool_state) {
-        case SpoolState::SHUT_DOWN:
-            // sends minimum values out to the motors
-            rc_write(AP_MOTORS_MOT_1, output_to_pwm(0)); // rotor
-            rc_write(AP_MOTORS_MOT_4, output_to_pwm(0)); // tail
-            rc_write_angle(AP_MOTORS_MOT_2, 0); // pitch
-            rc_write_angle(AP_MOTORS_MOT_3, 0); // roll
-            break;
-        case SpoolState::GROUND_IDLE:
-            // sends output to motors when armed but not flying
-            rc_write_angle(AP_MOTORS_MOT_2, 0);
-            rc_write_angle(AP_MOTORS_MOT_3, 0);
-            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_1], actuator_spin_up_to_ground_idle()); // spin up motors
-            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_4], actuator_spin_up_to_ground_idle());
-            rc_write(AP_MOTORS_MOT_1, output_to_pwm(_actuator[AP_MOTORS_MOT_1]));
-            rc_write(AP_MOTORS_MOT_4, output_to_pwm(_actuator[AP_MOTORS_MOT_4]));
-            break;
-        case SpoolState::SPOOLING_UP:
-        case SpoolState::THROTTLE_UNLIMITED:
-        case SpoolState::SPOOLING_DOWN:
-            // set motor output based on thrust requests
-            rc_write_angle(AP_MOTORS_MOT_2, _pitch_action * AP_MOTORS_COAX_SERVO_INPUT_RANGE); // pitch
-            rc_write_angle(AP_MOTORS_MOT_3, _roll_action * AP_MOTORS_COAX_SERVO_INPUT_RANGE); // roll
-            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_1], thrust_to_actuator(_rotor_thrust));
-            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_4], thrust_to_actuator(_tail_thrust));
-            rc_write(AP_MOTORS_MOT_1, output_to_pwm(_actuator[AP_MOTORS_MOT_1]));
-            rc_write(AP_MOTORS_MOT_4, output_to_pwm(_actuator[AP_MOTORS_MOT_4]));
-            break;
+    case SpoolState::SHUT_DOWN:
+        // sends minimum values out to the motors
+        rc_write(AP_MOTORS_MOT_1, output_to_pwm(0)); // rotor
+        rc_write(AP_MOTORS_MOT_4, output_to_pwm(0)); // tail
+        rc_write_angle(AP_MOTORS_MOT_2, 0); // pitch
+        rc_write_angle(AP_MOTORS_MOT_3, 0); // roll
+        break;
+    case SpoolState::GROUND_IDLE:
+        // sends output to motors when armed but not flying
+        rc_write_angle(AP_MOTORS_MOT_2, 0);
+        rc_write_angle(AP_MOTORS_MOT_3, 0);
+        set_actuator_with_slew(_actuator[AP_MOTORS_MOT_1], actuator_spin_up_to_ground_idle()); // spin up motors
+        set_actuator_with_slew(_actuator[AP_MOTORS_MOT_4], actuator_spin_up_to_ground_idle());
+        rc_write(AP_MOTORS_MOT_1, output_to_pwm(_actuator[AP_MOTORS_MOT_1]));
+        rc_write(AP_MOTORS_MOT_4, output_to_pwm(_actuator[AP_MOTORS_MOT_4]));
+        break;
+    case SpoolState::SPOOLING_UP:
+    case SpoolState::THROTTLE_UNLIMITED:
+    case SpoolState::SPOOLING_DOWN:
+        // set motor output based on thrust requests
+        rc_write_angle(AP_MOTORS_MOT_2, _pitch_action * AP_MOTORS_COAX_SERVO_INPUT_RANGE); // pitch
+        rc_write_angle(AP_MOTORS_MOT_3, _roll_action * AP_MOTORS_COAX_SERVO_INPUT_RANGE); // roll
+        set_actuator_with_slew(_actuator[AP_MOTORS_MOT_1], thrust_to_actuator(_rotor_thrust));
+        set_actuator_with_slew(_actuator[AP_MOTORS_MOT_4], thrust_to_actuator(_tail_thrust));
+        rc_write(AP_MOTORS_MOT_1, output_to_pwm(_actuator[AP_MOTORS_MOT_1]));
+        rc_write(AP_MOTORS_MOT_4, output_to_pwm(_actuator[AP_MOTORS_MOT_4]));
+        break;
     }
-    
+
 }
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
@@ -199,24 +199,24 @@ void AP_MotorsPulsing_Heli::_output_test_seq(uint8_t motor_seq, int16_t pwm)
 {
     // output to motors and servos
     switch (motor_seq) {
-        case 1:
-            // flap servo 1
-            rc_write(AP_MOTORS_MOT_1, pwm);
-            break;
-        case 2:
-            // flap servo 2
-            rc_write(AP_MOTORS_MOT_2, pwm);
-            break;
-        case 3:
-            // flap servo 3
-            rc_write(AP_MOTORS_MOT_3, pwm);
-            break;
-        case 4:
-            // flap servo 4
-            rc_write(AP_MOTORS_MOT_4, pwm);
-            break;
-        default:
-            // do nothing
-            break;
+    case 1:
+        // flap servo 1
+        rc_write(AP_MOTORS_MOT_1, pwm);
+        break;
+    case 2:
+        // flap servo 2
+        rc_write(AP_MOTORS_MOT_2, pwm);
+        break;
+    case 3:
+        // flap servo 3
+        rc_write(AP_MOTORS_MOT_3, pwm);
+        break;
+    case 4:
+        // flap servo 4
+        rc_write(AP_MOTORS_MOT_4, pwm);
+        break;
+    default:
+        // do nothing
+        break;
     }
 }

--- a/libraries/AP_Motors/AP_MotorsPulsing_Heli.cpp
+++ b/libraries/AP_Motors/AP_MotorsPulsing_Heli.cpp
@@ -57,7 +57,7 @@ void AP_MotorsPulsing_Heli::init(motor_frame_class frame_class, motor_frame_type
     motor_enabled[AP_MOTORS_MOT_4] = true;
 
     _mav_type = MAV_TYPE_QUADROTOR;
-    rpm = AP_RPM::get_singleton();
+
     // record successful initialisation if what we setup was the desired frame_class
     // GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Frame");
     set_initialised_ok(frame_class == MOTOR_FRAME_PULSING_HELI);
@@ -149,7 +149,7 @@ void AP_MotorsPulsing_Heli::output_armed_stabilizing()
     // gyro ff and yaw ff. Also need rotor height above COM
     Vector3f gyro_latest = _ahrs_view->get_gyro_latest();
     float velocity_0 = 0;
-    rpm->get_rpm(0, velocity_0);
+
     float rotor_yaw_ff = _rotor_yaw_ff * velocity_0 * velocity_0;
     Vector3f blade_omega(gyro_latest.x, gyro_latest.y, gyro_latest.z-velocity_0);
 

--- a/libraries/AP_Motors/AP_MotorsPulsing_Heli.cpp
+++ b/libraries/AP_Motors/AP_MotorsPulsing_Heli.cpp
@@ -1,0 +1,215 @@
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
+#include "AP_MotorsPulsing_Heli.h"
+#include <GCS_MAVLink/GCS.h>
+#include <SRV_Channel/SRV_Channel.h>
+
+extern const AP_HAL::HAL& hal;
+
+const AP_Param::GroupInfo AP_MotorsPulsing_Heli::var_info[] = {
+    AP_NESTEDGROUPINFO(AP_MotorsMulticopter, 0),
+    // @Param: YAW_DIR
+    // @DisplayName: Motor normal or reverse
+    // @Description: Used to change motor rotation directions without changing wires
+    // @Values: 1:normal,-1:reverse
+    // @User: Standard
+    AP_GROUPINFO("YAW_DIR", 1, AP_MotorsPulsing_Heli, _yaw_dir, 1),
+
+    // @Param: ROTOR_YAW_FF
+    // @DisplayName: Rotor torque FF gain
+    // @Description: Used to add a feed forward term to yaw that can compensate for rotor torque
+    // @Range: ? ?
+    // @Units: ?
+    // @Increment: float
+    // @User: Standard
+    AP_GROUPINFO("ROTOR_YAW_FF", 2, AP_MotorsPulsing_Heli, _rotor_yaw_ff, 0),
+    
+    // @Param: GYRO_FF
+    // @DisplayName: Rotor gyroscopic FF gain
+    // @Description: Used to add a feed forward term to compensate for the rotor's gyroscopic torque
+    // @Range: ? ?
+    // @Units: ?
+    // @Increment: float
+    // @User: Standard
+    AP_GROUPINFO("GYRO_FF", 3, AP_MotorsPulsing_Heli, _gyro_ff_gain, 0),
+
+    AP_GROUPEND
+};
+// init
+void AP_MotorsPulsing_Heli::init(motor_frame_class frame_class, motor_frame_type frame_type)
+{
+    
+    // make sure 4 output channels are mapped
+    for (uint8_t i = 0; i < 4; i++) {
+        add_motor_num(CH_1 + i);
+    }
+
+
+    // setup actuator scaling
+    SRV_Channels::set_angle(SRV_Channels::get_motor_function(1), AP_MOTORS_COAX_SERVO_INPUT_RANGE);
+    SRV_Channels::set_angle(SRV_Channels::get_motor_function(2), AP_MOTORS_COAX_SERVO_INPUT_RANGE);
+
+    motor_enabled[AP_MOTORS_MOT_1] = true;
+    motor_enabled[AP_MOTORS_MOT_4] = true;
+
+
+    _mav_type = MAV_TYPE_QUADROTOR;
+    rpm = AP_RPM::get_singleton();
+    // record successful initialisation if what we setup was the desired frame_class
+    // GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Frame");
+    set_initialised_ok(frame_class == MOTOR_FRAME_PULSING_HELI);
+}
+
+// set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
+void AP_MotorsPulsing_Heli::set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type)
+{
+    set_initialised_ok(frame_class == MOTOR_FRAME_PULSING_HELI);
+}
+
+// set update rate to motors - a value in hertz
+void AP_MotorsPulsing_Heli::set_update_rate(uint16_t speed_hz)
+{
+    // record requested speed
+    _speed_hz = speed_hz;
+
+    uint32_t mask =
+        1U << AP_MOTORS_MOT_5 |
+        1U << AP_MOTORS_MOT_6 ;
+    rc_set_freq(mask, _speed_hz);
+}
+
+void AP_MotorsPulsing_Heli::output_to_motors()
+{
+    switch (_spool_state) {
+        case SpoolState::SHUT_DOWN:
+            // sends minimum values out to the motors
+            rc_write(AP_MOTORS_MOT_1, output_to_pwm(0)); // rotor
+            rc_write(AP_MOTORS_MOT_4, output_to_pwm(0)); // tail
+            rc_write_angle(AP_MOTORS_MOT_2, 0); // pitch
+            rc_write_angle(AP_MOTORS_MOT_3, 0); // roll
+            break;
+        case SpoolState::GROUND_IDLE:
+            // sends output to motors when armed but not flying
+            rc_write_angle(AP_MOTORS_MOT_2, 0);
+            rc_write_angle(AP_MOTORS_MOT_3, 0);
+            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_1], actuator_spin_up_to_ground_idle()); // spin up motors
+            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_4], actuator_spin_up_to_ground_idle());
+            rc_write(AP_MOTORS_MOT_1, output_to_pwm(_actuator[AP_MOTORS_MOT_1]));
+            rc_write(AP_MOTORS_MOT_4, output_to_pwm(_actuator[AP_MOTORS_MOT_4]));
+            break;
+        case SpoolState::SPOOLING_UP:
+        case SpoolState::THROTTLE_UNLIMITED:
+        case SpoolState::SPOOLING_DOWN:
+            // set motor output based on thrust requests
+            rc_write_angle(AP_MOTORS_MOT_2, _pitch_action * AP_MOTORS_COAX_SERVO_INPUT_RANGE); // pitch
+            rc_write_angle(AP_MOTORS_MOT_3, _roll_action * AP_MOTORS_COAX_SERVO_INPUT_RANGE); // roll
+            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_1], thrust_to_actuator(_rotor_thrust));
+            set_actuator_with_slew(_actuator[AP_MOTORS_MOT_4], thrust_to_actuator(_tail_thrust));
+            rc_write(AP_MOTORS_MOT_1, output_to_pwm(_actuator[AP_MOTORS_MOT_1]));
+            rc_write(AP_MOTORS_MOT_4, output_to_pwm(_actuator[AP_MOTORS_MOT_4]));
+            break;
+    }
+    
+}
+
+// get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
+//  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
+uint32_t AP_MotorsPulsing_Heli::get_motor_mask()
+{
+    uint32_t motor_mask =
+        1U << AP_MOTORS_MOT_1 |
+        1U << AP_MOTORS_MOT_4;
+    uint32_t mask = motor_mask_to_srv_channel_mask(motor_mask);
+
+    // add parent's mask
+    mask |= AP_MotorsMulticopter::get_motor_mask();
+
+    return mask;
+}
+
+void AP_MotorsPulsing_Heli::output_armed_stabilizing()
+{
+    float   roll_thrust;                // roll thrust input value, +/- 1.0
+    float   pitch_thrust;               // pitch thrust input value, +/- 1.0
+    float   yaw_thrust;                 // yaw thrust input value, +/- 1.0
+    float   throttle_thrust;            // throttle thrust input value, 0.0 - 1.0
+    float   throttle_avg_max;           // throttle thrust average maximum value, 0.0 - 1.0
+    float   rp_scale = 1.0f;           // this is used to scale the roll, pitch and yaw to fit within the motor limits
+
+    // gyro ff and yaw ff. Also need rotor height above COM
+    Vector3f gyro_latest = _ahrs_view->get_gyro_latest();
+    float velocity_0 = 0;
+    rpm->get_rpm(0, velocity_0);
+    float rotor_yaw_ff = _rotor_yaw_ff * velocity_0 * velocity_0;
+    Vector3f blade_omega(gyro_latest.x, gyro_latest.y, gyro_latest.z-velocity_0);
+
+    Vector3f omega_cross = gyro_latest%blade_omega;
+
+    float gyro_x_ff = omega_cross.x * _gyro_ff_gain;
+    float gyro_y_ff = omega_cross.y * _gyro_ff_gain;
+
+
+    // apply voltage and air pressure compensation
+    const float compensation_gain = get_compensation_gain();
+    roll_thrust = (_roll_in + _roll_in_ff + gyro_x_ff) * compensation_gain;
+    pitch_thrust = (_pitch_in + _pitch_in_ff + gyro_y_ff) * compensation_gain;
+    yaw_thrust = (_yaw_in + _yaw_in_ff + rotor_yaw_ff) * compensation_gain;
+    throttle_thrust = get_throttle() * compensation_gain;
+    throttle_avg_max = _throttle_avg_max * compensation_gain;
+
+
+    // sanity check throttle is above zero and below current limited throttle
+    if (throttle_thrust <= 0.0f) {
+        throttle_thrust = 0.0f;
+        limit.throttle_lower = true;
+    }
+    if (throttle_thrust >= _throttle_thrust_max) {
+        throttle_thrust = _throttle_thrust_max;
+        limit.throttle_upper = true;
+    }
+
+    throttle_avg_max = constrain_float(throttle_avg_max, throttle_thrust, _throttle_thrust_max);
+
+
+
+
+    // calculate the throttle setting for the lift fan
+    // compensation_gain can never be zero
+    _throttle_out = throttle_avg_max / compensation_gain;
+
+    _roll_action = roll_thrust * rp_scale;
+    _pitch_action = pitch_thrust * rp_scale;
+
+    _rotor_thrust = _throttle_out;
+    _tail_thrust = _yaw_dir * yaw_thrust;
+}
+
+
+// output_test_seq - spin a motor at the pwm value specified
+//  motor_seq is the motor's sequence number from 1 to the number of motors on the frame
+//  pwm value is an actual pwm value that will be output, normally in the range of 1000 ~ 2000
+void AP_MotorsPulsing_Heli::_output_test_seq(uint8_t motor_seq, int16_t pwm)
+{
+    // output to motors and servos
+    switch (motor_seq) {
+        case 1:
+            // flap servo 1
+            rc_write(AP_MOTORS_MOT_1, pwm);
+            break;
+        case 2:
+            // flap servo 2
+            rc_write(AP_MOTORS_MOT_2, pwm);
+            break;
+        case 3:
+            // flap servo 3
+            rc_write(AP_MOTORS_MOT_3, pwm);
+            break;
+        case 4:
+            // flap servo 4
+            rc_write(AP_MOTORS_MOT_4, pwm);
+            break;
+        default:
+            // do nothing
+            break;
+    }
+}

--- a/libraries/AP_Motors/AP_MotorsPulsing_Heli.h
+++ b/libraries/AP_Motors/AP_MotorsPulsing_Heli.h
@@ -1,0 +1,51 @@
+#pragma once
+#include <AP_Common/AP_Common.h>
+#include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
+#include <AP_AHRS/AP_AHRS_View.h>
+#include <AP_RPM/AP_RPM.h>
+#include "AP_MotorsMulticopter.h"
+
+#define AP_MOTORS_COAX_POSITIVE      1
+#define AP_MOTORS_COAX_NEGATIVE     -1
+
+#define AP_MOTORS_COAX_SERVO_INPUT_RANGE    4500
+
+class AP_MotorsPulsing_Heli : public AP_MotorsMulticopter {
+public:
+    AP_MotorsPulsing_Heli(AP_AHRS_View  *ahrs_view, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
+        AP_MotorsMulticopter(speed_hz), _ahrs_view(ahrs_view)
+    {
+        AP_Param::setup_object_defaults(this, var_info);
+    }
+
+    void            init(motor_frame_class frame_class, motor_frame_type frame_type) override;
+    void            set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) override;
+    void            set_update_rate( uint16_t speed_hz ) override;
+    virtual void    output_to_motors() override;
+    uint32_t        get_motor_mask() override;
+    bool            arming_checks(size_t buflen, char *buffer) const override { return AP_Motors::arming_checks(buflen, buffer); }
+    static const struct AP_Param::GroupInfo        var_info[];
+
+protected:
+    // output - sends commands to the motors
+    void            output_armed_stabilizing() override;
+
+    float           _rotor_thrust;
+    float           _tail_thrust;
+    float           _pitch_action;
+    float           _roll_action;
+
+    AP_AHRS_View    *_ahrs_view;
+    AP_RPM          *rpm;
+    
+    AP_Int8         _yaw_dir;
+    AP_Float        _rotor_yaw_ff;
+    AP_Float        _gyro_ff_gain;
+
+    const char*     _get_frame_string() const override { return "PULSE"; }
+
+    // output_test_seq - spin a motor at the pwm value specified
+    //  motor_seq is the motor's sequence number from 1 to the number of motors on the frame
+    //  pwm value is an actual pwm value that will be output, normally in the range of 1000 ~ 2000
+    virtual void    _output_test_seq(uint8_t motor_seq, int16_t pwm) override;
+};

--- a/libraries/AP_Motors/AP_MotorsPulsing_Heli.h
+++ b/libraries/AP_Motors/AP_MotorsPulsing_Heli.h
@@ -10,20 +10,37 @@
 
 #define AP_MOTORS_COAX_SERVO_INPUT_RANGE    4500
 
+//This class defines a helecopter frame that uses pulsing motors
+
 class AP_MotorsPulsing_Heli : public AP_MotorsMulticopter {
 public:
+    //Create an instance of a Pulsing Heli object
     AP_MotorsPulsing_Heli(AP_AHRS_View  *ahrs_view, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
         AP_MotorsMulticopter(speed_hz), _ahrs_view(ahrs_view)
     {
         AP_Param::setup_object_defaults(this, var_info);
     }
 
+    //Intialize the frame
     void            init(motor_frame_class frame_class, motor_frame_type frame_type) override;
+
+    // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
     void            set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) override;
+
+    // set update rate to motors - a value in hertz
     void            set_update_rate( uint16_t speed_hz ) override;
+
+    //Updates the output values to all motors
     virtual void    output_to_motors() override;
+
+    // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
+    //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
     uint32_t        get_motor_mask() override;
+    
+    //Returns whether or not initialization was successful
     bool            arming_checks(size_t buflen, char *buffer) const override { return AP_Motors::arming_checks(buflen, buffer); }
+    
+    //Stores the group information for a pulsing helicopter
     static const struct AP_Param::GroupInfo        var_info[];
 
 protected:

--- a/libraries/AP_Motors/AP_MotorsPulsing_Heli.h
+++ b/libraries/AP_Motors/AP_MotorsPulsing_Heli.h
@@ -12,7 +12,8 @@
 
 //This class defines a helecopter frame that uses pulsing motors
 
-class AP_MotorsPulsing_Heli : public AP_MotorsMulticopter {
+class AP_MotorsPulsing_Heli : public AP_MotorsMulticopter
+{
 public:
     //Create an instance of a Pulsing Heli object
     AP_MotorsPulsing_Heli(AP_AHRS_View  *ahrs_view, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
@@ -36,10 +37,13 @@ public:
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
     uint32_t        get_motor_mask() override;
-    
+
     //Returns whether or not initialization was successful
-    bool            arming_checks(size_t buflen, char *buffer) const override { return AP_Motors::arming_checks(buflen, buffer); }
-    
+    bool            arming_checks(size_t buflen, char *buffer) const override
+    {
+        return AP_Motors::arming_checks(buflen, buffer);
+    }
+
     //Stores the group information for a pulsing helicopter
     static const struct AP_Param::GroupInfo        var_info[];
 
@@ -54,12 +58,15 @@ protected:
 
     AP_AHRS_View    *_ahrs_view;
     AP_RPM          *rpm;
-    
+
     AP_Int8         _yaw_dir;
     AP_Float        _rotor_yaw_ff;
     AP_Float        _gyro_ff_gain;
 
-    const char*     _get_frame_string() const override { return "PULSE"; }
+    const char*     _get_frame_string() const override
+    {
+        return "PULSE";
+    }
 
     // output_test_seq - spin a motor at the pwm value specified
     //  motor_seq is the motor's sequence number from 1 to the number of motors on the frame

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -75,6 +75,7 @@ public:
         MOTOR_FRAME_6DOF_SCRIPTING = 16,
         MOTOR_FRAME_DYNAMIC_SCRIPTING_MATRIX = 17,
         MOTOR_FRAME_PULSING_COAX = 18,
+        MOTOR_FRAME_PULSING_HELI = 19,
     };
 
     // return string corresponding to frame_class


### PR DESCRIPTION
Adds the helicopter vehicle class into the target PR branch. The actual code changes made are as follows:

1. Added a new member to motor_frame_class for MOTOR_FRAME_PULSING_HELI that is one after PULSING_COAX
2. Added pusling heli creation to system.cpp
3. Renamed the coax motor class to AP_MotorsPulsing_Coax instead of just AP_MotorsPulsing
4. Renamed heli motor class to AP_MotorsPulsing_Heli instead of just AP_MotorsPulsing
5. Renamed the AP_MotorsPulsing source files to AP_MotorsPulsing_Heli
6. Updated AP_MotorsPulsing_Heli get_motor_mask function to account for all of the outputs we're using (main throttle, pitch, roll, and tail throttle)
7. Deleted rpm references in output_armed_stabalizing()  and init() from AP_MotorsPulsing_Heli as discussed with Luca
8. Ran auto-format on everything, and added some comments

Testing done:
1. Configure the flight controller as a coax controller
2. Configure the motor properly
3. Ensure that the motor spins, and has pulsing happening when controlled via QGroundControl virtual joysticks
4. Reconfigure the flight controller and motor to work as a heli with the motor as the main rotor
5. Repeat 2 and 3